### PR TITLE
Authentification Service removed from individual providers

### DIFF
--- a/Kochbuch/src/app/rezeptanlegen/rezeptanlegen.component.ts
+++ b/Kochbuch/src/app/rezeptanlegen/rezeptanlegen.component.ts
@@ -19,7 +19,7 @@ import {IngredientSmall} from "./rezeptanlegen.model";
   selector: 'app-rezeptanlegen',
   templateUrl: './rezeptanlegen.component.html',
   styleUrls: ['./rezeptanlegen.component.css'],
-  providers: [TagSearchService, IngredientSearchService, RezeptanlegenService, AuthenticationService]
+  providers: [TagSearchService, IngredientSearchService, RezeptanlegenService]
 })
 export class RezeptanlegenComponent {
 


### PR DESCRIPTION
Wenn der AuthService in der Komponentenspezifischen Providerliste steht, wird eine neue Instanz erstellt, folglich kann die Concurrency mit dem sonst verwendeten AuthService nicht garantiert werden.